### PR TITLE
Introducing a kernel lock primitive

### DIFF
--- a/kudos/kernel/klock.c
+++ b/kudos/kernel/klock.c
@@ -4,18 +4,18 @@
 
 void
 klock_init(klock_t *klock) {
-  spinlock_reset(&klock);
+  spinlock_reset(klock);
 }
 
 klock_status_t
 klock_lock(klock_t *klock) {
   interrupt_status_t st = _interrupt_disable();
-  spinlock_acquire(&klock);
+  spinlock_acquire(klock);
   return st;
 }
 
 void
 klock_open(klock_status_t st, klock_t *klock) {
-  spinlock_release(&klock);
+  spinlock_release(klock);
   _interrupt_set_state(st);
 }

--- a/kudos/kernel/klock.c
+++ b/kudos/kernel/klock.c
@@ -1,0 +1,21 @@
+/// Kernel lock. A convenient wrapper.
+
+#include "kernel/klock.h"
+
+void
+klock_init(klock_t *klock) {
+  spinlock_reset(&klock);
+}
+
+klock_status_t
+klock_lock(klock_t *klock) {
+  interrupt_status_t st = _interrupt_disable();
+  spinlock_acquire(&klock);
+  return st;
+}
+
+void
+klock_open(klock_status_t st, klock_t *klock) {
+  spinlock_release(&klock);
+  _interrupt_set_state(st);
+}

--- a/kudos/kernel/klock.h
+++ b/kudos/kernel/klock.h
@@ -1,0 +1,18 @@
+/// Kernel lock. A convenient wrapper.
+
+#ifndef KUDOS_KERNEL_KLOCK_H
+#define KUDOS_KERNEL_KLOCK_H
+
+#include "kernel/interrupt.h"
+#include "kernel/spinlock.h"
+
+typedef interrupt_status_t klock_status_t;
+
+typedef spinlock_t klock_t;
+
+void klock_init(klock_t *klock);
+
+klock_status_t klock_lock(klock_t *klock);
+void klock_open(klock_status_t, klock_t *klock);
+
+#endif // KUDOS_KERNEL_KLOCK_H

--- a/kudos/kernel/module.mk
+++ b/kudos/kernel/module.mk
@@ -3,6 +3,6 @@
 # Set the module name
 MODULE := kernel
 
-FILES := panic.c thread.c scheduler.c sleepq.c semaphore.c halt.c stalloc.c
+FILES := panic.c thread.c scheduler.c sleepq.c semaphore.c halt.c stalloc.c klock.c
 
 SRC += $(patsubst %, $(MODULE)/%, $(FILES))


### PR DESCRIPTION
This is to abstract away from the fact that you should *both* disable interrupts and
take hold a spinlock to protect anything in KUDOS.

RFC @Athas 